### PR TITLE
add --no-init & --rclnodejs-version cli flags

### DIFF
--- a/package-creation-tool/README.md
+++ b/package-creation-tool/README.md
@@ -20,6 +20,7 @@ Alternatively using npx:
   npx rclnodejs-cli create-package <package_name>
   npx rclnodejs-cli create-package <package_name> --typescript
 ```
+Be aware that when using `npx` to run `rclnodejs-cli`, this package includes a dependency on the rclnodejs package which has a lengthy install postinstall step. Thus if you frequently use `rclnodejs-cli` you may benefit from more responsiveness by installing this package globally.
 
 View the `create-package` options:
 ```
@@ -34,7 +35,7 @@ or
  | | | (__| | | | | (_) | (_| |  __/| \__ \
  |_|  \___|_|_| |_|\___/ \__,_|\___|/ |___/
                                   |__/
-Usage: rclnodejs-cli create-package <package_name> [options...]
+Usage: rclnodejs create-package <package_name> [options...]
 
 Create a ROS2 package for Nodejs development.
 
@@ -42,10 +43,11 @@ Options:
   --description <description>               The description given in the package.xml
   --destination-directory <directory_path>  Directory where to create the package directory
   --license <license>                       The license attached to this package
-  --maintainer-email <email>                email address of the maintainer of this package
-  --maintainer-name <name>                  name of the maintainer of this package
-  --typescript                              Configure as a TypeScript Node.js project
+  --maintainer-email <email>                Email address of the maintainer of this package
+  --maintainer-name <name>                  Name of the maintainer of this package
   --no-init                                 Do not run "npm init"
+  --rclnodejs-version <x.y.z>               The version of rclnodejs to use
+  --typescript                              Configure as a TypeScript Node.js project
   --dependencies <ros_packages...>          list of ROS dependencies
   -h, --help                                display help for command
 ```

--- a/package-creation-tool/lib/package_creator.js
+++ b/package-creation-tool/lib/package_creator.js
@@ -8,14 +8,14 @@ class PkgCreator {
     createPkgCmd
       .usage('<package_name> [options...]')
       .description('Create a ROS2 package for Nodejs development.')
-      // .option('--rclnodejs-version <x.y.z>', 'The version of rclnodejs to use')
       .option('--description <description>', 'The description given in the package.xml')
       .option('--destination-directory <directory_path>', 'Directory where to create the package directory')
       .option('--license <license>', 'The license attached to this package')
-      .option('--maintainer-email <email>', 'email address of the maintainer of this package')
-      .option('--maintainer-name <name>', 'name of the maintainer of this package')
-      .option('--typescript', 'Configure as a TypeScript Node.js project')
+      .option('--maintainer-email <email>', 'Email address of the maintainer of this package')
+      .option('--maintainer-name <name>', 'Name of the maintainer of this package')
       .option('--no-init', 'Do not run "npm init"')
+      .option('--rclnodejs-version <x.y.z>', 'The version of rclnodejs to use')
+      .option('--typescript', 'Configure as a TypeScript Node.js project')
       .option('--dependencies <ros_packages...>', 'list of ROS dependencies')
       .action((packageName, options) => {
         this.createPackage(packageName, options);
@@ -35,9 +35,9 @@ class PkgCreator {
     let cmd = path.join(__dirname, '..', 'scripts', script);
     cmd += ` ${packageName}`;
 
-    // if (options.rclnodejsVersion) {
-    //   cmd += ` --rclnodejs-version "${options.rclnodejsVersion}"`;
-    // }
+    if (options.rclnodejsVersion) {
+      cmd += ` --rclnodejs-version "${options.rclnodejsVersion}"`;
+    }
 
     if (options.description) {
       cmd += ` --description "${options.description}"`;
@@ -57,6 +57,10 @@ class PkgCreator {
 
     if (options.maintainerName) {
       cmd += ` --maintainer-name "${options.maintainerName}"`;
+    }
+
+    if (options.noInit) {
+      cmd += ' --no-init';
     }
 
     if (options.typescript) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rclnodejs-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Commandline tools for the ROS2 rclnodejs client library",
   "main": "index.js",
   "bin": "./index.js",
@@ -8,7 +8,8 @@
     "test": "test"
   },
   "scripts": {
-    "postinstall": "colcon build --base-paths package-creation-tool && node scripts/set_script_permissions.js",
+    "postinstall": "npm run build-package-creation-tool && node scripts/set_script_permissions.js",
+    "build-package-creation-tool": "colcon build --base-paths package-creation-tool",
     "test": "mocha",
     "lint": "eslint --max-warnings=0 --ext js index.js src message-generator-tool package-creation-tool test"
   },

--- a/test/run_ros_version.bat
+++ b/test/run_ros_version.bat
@@ -1,0 +1,2 @@
+echo off
+install\local_setup.bat && echo on && echo %ROS_DISTRO%

--- a/test/run_ros_version.sh
+++ b/test/run_ros_version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 source install/local_setup.sh && \
-printenv $ROS_DISTRO
+echo $ROS_DISTRO

--- a/test/run_ros_version.sh
+++ b/test/run_ros_version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source install/local_setup.sh && \
+printenv $ROS_DISTRO


### PR DESCRIPTION
Note-1: the value of the --rclnodejs-version flag is not validated to specify an existing version nor is it's format validated, e.g., x.y.z 

Note-2: when --no-init is present a --rclnodejs-version flag is ignored and never used.

Fix #13