### PR TITLE
Adds --no-ros-pkg, updates pkg deps, ts target & libs to es2020, v0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ script:
   - 'if [ "$DOCKER_USERNAME" != "" ]; then sudo docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD; fi'
   - sudo docker pull ubuntu:focal
   - sudo docker build -t rcldocker .
+<<<<<<< Upstream, based on origin/develop
   - docker run -v $(pwd):/ros2/rclnodejs-cli --rm rcldocker bash -i -c '\. $NVM_DIR/nvm.sh && nvm use v16 && cp -R /ros2/rclnodejs-cli ~/rclnodejs-cli && chown -R rclnodejs-user ~/rclnodejs-cli && cd ~/rclnodejs-cli && npm install --unsafe-perm && npm test'
+=======
+  - docker run -v $(pwd):/ros2/rclnodejs-cli --rm rcldocker bash -i -c '\. $NVM_DIR/nvm.sh && nvm use v16 && cp -R /ros2/rclnodejs-cli ~/rclnodejs && chown -R rclnodejs-user ~/rclnodejs-cli && cd ~/rclnodejs-cli && npm install --unsafe-perm && npm test'
+>>>>>>> 2c66a13 fix travis syntax issue

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,12 @@ WORKDIR /home/rclnodejs-user
 RUN echo "source $ROS2_WS/ros2-linux/local_setup.bash" >> $HOME/.bashrc
 
 # Install nvm, Node.js and node-gyp
+<<<<<<< Upstream, based on origin/develop
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 RUN  bash -c "\. .nvm/nvm.sh && nvm install lts/gallium"
+=======
+ENV NODE_VERSION lts/gallium
+RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash
+
+ENV PATH /bin/versions/node/$NODE_VERSION/bin:$PATH
+>>>>>>> 6d231d2 Updated docker node to v16

--- a/package-creation-tool/README.md
+++ b/package-creation-tool/README.md
@@ -1,13 +1,14 @@
 # `create-package` command
-The `rclnodejs-cli create-package` command creates a hybrid ROS2-Nodejs package that can coexist and participate with other ROS2 packages in a ROS2 workspace and be run using the ROS2 `launch` facility. A ROS2-Nodejs package consist of a ROS2 package, specifically an `ament-cmake` ROS2 package, overlaid with a Nodejs package. This command can also be run from the `ros2` cli as described in the [Using the command from the `ros2` commandline](#Using-the-command-from-the-ros2-commandline) section. 
+The `rclnodejs-cli create-package` command creates a hybrid ROS2-Nodejs package that can coexist and participate with other ROS 2 packages in a ROS 2 workspace and be run using the ROS 2 `launch` facility. A ROS2-Nodejs package consist of a ROS 2 package, specifically an `ament-cmake` ROS 2 package, overlaid with a Nodejs package. This command can also be run from the `ros2` commandline as described in the [Using the command from the `ros2` commandline](#Using-the-command-from-the-ros2-commandline) section. 
 
 ## Key Features
-* Creates a ROS2 ament_cmake packages and overlays it with a custom Nodejs package.
+* Creates a ROS 2 ament_cmake package and overlays it with a custom Nodejs package.
 * `--typescript` commandline option to configure the package for use with TypeScript.
-* Includes the ROS2 JavaScript client library, 
+* Includes the ROS 2 JavaScript client library, 
 [rclnodejs](https://github.com/RobotWebTools/rclnodejs) as a runtime dependency.
 * Creates and example JavaScript/TypeScript ROS2 publisher node and ROS2 launch-description.
 * Customized `CMakeList.txt` `install()` rules to install key runtime files to the package share/ folder
+* `--no-ros-pkg` commandline option to create omit the ROS 2 package creation and only create a Nodejs package.
 
 # Usage #
 Create a new ROS2-Nodejs package basic usage:
@@ -102,7 +103,7 @@ We can now use the `ros2 launch` command to run the `example.launch.py` launch-d
 
 Launch `example.launch.py` as shown below:
 ```
-  ros2 launch ros2_nodejs example.launch.py
+  ros2 launch <package-name> example.launch.py
 ```
 To view the messages being published to the `foo` topic, open a separate shell configured with your ROS2 environment and enter:
 ```

--- a/package-creation-tool/lib/package_creator.js
+++ b/package-creation-tool/lib/package_creator.js
@@ -16,6 +16,7 @@ class PkgCreator {
       .option('--no-init', 'Do not run "npm init"')
       .option('--rclnodejs-version <x.y.z>', 'The version of rclnodejs to use')
       .option('--typescript', 'Configure as a TypeScript Node.js project')
+      .option('--no-ros-pkg', 'Do not create a ROS 2 package, e.g, package.xml')
       .option('--dependencies <ros_packages...>', 'list of ROS dependencies')
       .action((packageName, options) => {
         this.createPackage(packageName, options);
@@ -60,11 +61,15 @@ class PkgCreator {
     }
 
     if (options.noInit) {
-      cmd += ' --no-init';
+      cmd += ' --no-npm-init';
     }
 
     if (options.typescript) {
       cmd += ' --typescript';
+    }
+
+    if (!options.rosPkg) {
+      cmd += ' --no-ros-pkg';
     }
 
     if (options.dependencies) {

--- a/package-creation-tool/package.xml
+++ b/package-creation-tool/package.xml
@@ -3,9 +3,15 @@
 <package format="3">
   <name>rclnodejs_pkg_creation_tool</name>
   <version>0.0.1</version>
+<<<<<<< Upstream, based on origin/develop
   <description>Creates hybrid ros2-nodejs package</description>
   <maintainer email="5588978+wayneparrott@users.noreply.github.com">Wayne  Parrott</maintainer>
   <license>APL2</license>
+=======
+  <description>TODO: Package description</description>
+  <maintainer email="you@youremail.com">yourname</maintainer>
+  <license>TODO: License declaration</license>
+>>>>>>> 2bb8c33 Support node 13-17, ts 4.5, bump to v0.2, minor fixes and tweaks
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/package-creation-tool/package.xml
+++ b/package-creation-tool/package.xml
@@ -4,6 +4,7 @@
   <name>rclnodejs_pkg_creation_tool</name>
   <version>0.0.1</version>
 <<<<<<< Upstream, based on origin/develop
+<<<<<<< Upstream, based on origin/develop
   <description>Creates hybrid ros2-nodejs package</description>
   <maintainer email="5588978+wayneparrott@users.noreply.github.com">Wayne  Parrott</maintainer>
   <license>APL2</license>
@@ -12,6 +13,11 @@
   <maintainer email="you@youremail.com">yourname</maintainer>
   <license>TODO: License declaration</license>
 >>>>>>> 2bb8c33 Support node 13-17, ts 4.5, bump to v0.2, minor fixes and tweaks
+=======
+  <description>Creates hybrid ros2-nodejs package</description>
+  <maintainer email="5588978+wayneparrott@users.noreply.github.com">Wayne  Parrott</maintainer>
+  <license>APL2</license>
+>>>>>>> d5bf08f Added email, license & description to package-creation-tool package.xml
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/package.json.em
+++ b/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/package.json.em
@@ -15,10 +15,10 @@
   "dependencies": {
   },
   "devDependencies": {
-    "@@types/node": "ts4.5",
-    "nodemon": "^2.0.15",
-    "ts-node": "^10.5.0",
-    "typescript": "^4.5.0"
+    "@@types/node": "^18.15.0",
+    "nodemon": "^2.0.21",
+    "ts-node": "^10.9.0",
+    "typescript": "^4.9.0"
   }
 
 }

--- a/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/tsconfig.json
+++ b/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2019",
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+    "esModuleInterop": true,
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/package-creation-tool/rclnodejs_pkg_creation_tool/verb/create_nodejs_pkg.py
+++ b/package-creation-tool/rclnodejs_pkg_creation_tool/verb/create_nodejs_pkg.py
@@ -80,54 +80,73 @@ class CreateROS2NodeJsPkgVerb(VerbExtension):
             default=False,
             help='Configure as a TypeScript Node.js project')
         parser.add_argument(
+            '--no-ros-pkg',
+            action='store_true',
+            default=False,
+            help='Limit pkg creation to only the Nodejs package structure')
+        parser.add_argument(
             '--rclnodejs-version',
             help='Version of rclnodejs client library to use, x.y.z format')
 
     def main(self, *, args):
-        # run 'ros2 pkg create <package_name>'
-        ros2pkg_args = [
-            'ros2',
-            'pkg',
-            'create',
-            args.package_name,
-            '--description',
-            args.description,
-            '--license',
-            args.license,
-            '--destination-directory',
-            args.destination_directory,
-          ]
+        if not args.no_ros_pkg:
+          print('XXXXXXXXXXXXXX')
+          # run 'ros2 pkg create <package_name>'
+          ros2pkg_args = [
+              'ros2',
+              'pkg',
+              'create',
+              args.package_name,
+              '--description',
+              args.description,
+              '--license',
+              args.license,
+              '--destination-directory',
+              args.destination_directory,
+            ]
 
-        if args.maintainer_email:
-          ros2pkg_args.append('--maintainer-email')
-          ros2pkg_args.append(args.maintainer_email)
-        if args.dependencies:
-          ros2pkg_args.append('--dependencies')
-          ros2pkg_args.append(args.dependencies)
+          if args.maintainer_email:
+            ros2pkg_args.append('--maintainer-email')
+            ros2pkg_args.append(args.maintainer_email)
+          if args.dependencies:
+            ros2pkg_args.append('--dependencies')
+            ros2pkg_args.append(args.dependencies)
 
-        proc_result = subprocess.run(ros2pkg_args)
-        if proc_result.returncode != 0:
-          print('Unable to create package')
-          return ERROR_RETURN
+          proc_result = subprocess.run(ros2pkg_args)
+          if proc_result.returncode != 0:
+            print('Unable to create package')
+            return ERROR_RETURN
+
+          # verify cwd contains package.xml file
+          os.chdir(os.path.join(args.destination_directory, args.package_name))
+          cwd = os.getcwd()
+          if not package_exists_at(cwd):
+              print(f'  Current directory {cwd} does not contain a ROS {PACKAGE_MANIFEST_FILENAME} manifest file.')
+              return ERROR_RETURN
+
+          # parse package.xml
+          pkg = parse_package(cwd)
+
+        else:
+          pkgDir = os.path.join(args.destination_directory, args.package_name)
+
+          if os.path.exists(pkgDir):
+            print(f'  Package directory {cwd} already exists.')
+            return ERROR_RETURN
+
+          #manually create pkg folder
+          os.mkdir(pkgDir)
+          os.chdir(pkgDir)
+          cwd = os.getcwd()
 
         if args.typescript:
             print('Setting up Node.js and TypeScript.')
         else:
             print('Setting up Node.js.')
 
-        # verify cwd contains package.xml file
-        os.chdir(os.path.join(args.destination_directory, args.package_name))
-        cwd = os.getcwd()
-        if not package_exists_at(cwd):
-            print(f'  Current directory {cwd} does not contain a ROS {PACKAGE_MANIFEST_FILENAME} manifest file.')
-            return ERROR_RETURN
-
         template_dir_path = _get_template_dir_path(args)
         if _validate_template_dir(template_dir_path) == ERROR_RETURN:
             return ERROR_RETURN
-
-        # parse package.xml
-        pkg = parse_package(cwd)
 
         # copy all non-template files
         print('  Copy core Node.js files into package')
@@ -137,41 +156,50 @@ class CreateROS2NodeJsPkgVerb(VerbExtension):
         )
         shutil.copytree(template_dir_path, cwd, ignore=ignore_patterns, dirs_exist_ok=True)
         
+        if args.no_ros_pkg:
+          pkgjson_data = {
+              'name': args.package_name,
+              'version': "0.0.0",
+              'license': " ".join(args.license),
+              'description': args.description
+          }
+        else:
+          # create example launch file
+          print('  Creating example launch file, example.launch.py')
+          launch_data = {
+              'name': pkg.name
+          }
+          _expand_template(
+              os.path.join(template_dir_path, 'example.launch.em'),
+              launch_data,
+              os.path.join(cwd, 'launch', 'example.launch.py')
+          )
+
+          # update CMakeLists.txt with install() rules 
+          print('  Adding \'install()\' rules to CMakeLists.txt')
+          cmakelist_exists = os.path.exists(os.path.join(cwd, CMAKELISTS_FILENAME))
+          if not cmakelist_exists:
+              print(f'  Unable to setup cmake install rules. '
+                  'Current directory {cwd} does not contain a {CMAKELISTS_FILENAME} file.')
+          else:
+              _updateCMakeListsFile(
+                  os.path.join(template_dir_path, 'CMakeLists.install.em'),
+                  os.path.join(cwd, CMAKELISTS_FILENAME))
+          pkgjson_data = {
+              'name': pkg.name,
+              'version': pkg.version,
+              'license': " ".join(pkg.licenses),
+              'description': pkg.description
+          }
+
         # create package.json
         print('  Configuring package.json')
-        pkgjson_data = {
-            'name': pkg.name,
-            'version': pkg.version,
-            'license': " ".join(pkg.licenses),
-            'description': pkg.description
-        }
+
         _expand_template(
             os.path.join(template_dir_path, 'package.json.em'),
             pkgjson_data,
             os.path.join(cwd, 'package.json')
         )
-
-        # create example launch file
-        print('  Creating example launch file, example.launch.py')
-        launch_data = {
-            'name': pkg.name
-        }
-        _expand_template(
-            os.path.join(template_dir_path, 'example.launch.em'),
-            launch_data,
-            os.path.join(cwd, 'launch', 'example.launch.py')
-        )
-
-        # update CMakeLists.txt with install() rules 
-        print('  Adding \'install()\' rules to CMakeLists.txt')
-        cmakelist_exists = os.path.exists(os.path.join(cwd, CMAKELISTS_FILENAME))
-        if not cmakelist_exists:
-            print(f'  Unable to setup cmake install rules. '
-                 'Current directory {cwd} does not contain a {CMAKELISTS_FILENAME} file.')
-        else:
-            _updateCMakeListsFile(
-                os.path.join(template_dir_path, 'CMakeLists.install.em'),
-                os.path.join(cwd, CMAKELISTS_FILENAME))
 
         if not args.no_init:
             # install all node.js dependencies in package.json
@@ -283,7 +311,7 @@ def _run_npm_install(args):
         return ERROR_RETURN
     
     print(f'  Running \'{os.path.basename(npm)} install\' command.')
-    subprocess.run([npm, 'install'])
+    subprocess.run([npm, 'install', 'rclnodejs'])
     rclnodejs_pkg = f"rclnodejs{'@' + args.rclnodejs_version if args.rclnodejs_version else ''}"
     return subprocess.run([npm, 'install', rclnodejs_pkg])
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rclnodejs-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Commandline tools for the ROS2 rclnodejs client library",
   "main": "index.js",
   "bin": "./index.js",
@@ -35,7 +35,7 @@
     "chalk": "^4.1.0",
     "commander": "^6.2.1",
     "figlet": "^1.5.0",
-    "rclnodejs": "^0.21.0"
+    "rclnodejs": "^0.21.4"
   },
   "devDependencies": {
     "deep-equal": "^1.1.1",
@@ -47,6 +47,6 @@
     "rimraf": "^3.0.2"
   },
   "engines": {
-    "node": ">= 10.23.1 <18.0.0"
+    "node": ">= 14.0.0"
   }
 }


### PR DESCRIPTION
Adds --no-ros-pkg commandline arg
This flag omits the creation of a ROS package, e.g., no package.xml or CMakefile.txt. 

Q: What is created when this flag is present? 
A: Only a Nodejs package is created, e.g., package.json, example JS node.

Updated the tsconfig.json template support ES2020 target and libs.