### PR TITLE
Adds --no-ros-pkg, updates pkg deps, ts target & libs to es2020, v0.3.0

### DIFF
--- a/package-creation-tool/README.md
+++ b/package-creation-tool/README.md
@@ -1,13 +1,14 @@
 # `create-package` command
-The `rclnodejs-cli create-package` command creates a hybrid ROS2-Nodejs package that can coexist and participate with other ROS2 packages in a ROS2 workspace and be run using the ROS2 `launch` facility. A ROS2-Nodejs package consist of a ROS2 package, specifically an `ament-cmake` ROS2 package, overlaid with a Nodejs package. This command can also be run from the `ros2` cli as described in the [Using the command from the `ros2` commandline](#Using-the-command-from-the-ros2-commandline) section. 
+The `rclnodejs-cli create-package` command creates a hybrid ROS2-Nodejs package that can coexist and participate with other ROS 2 packages in a ROS 2 workspace and be run using the ROS 2 `launch` facility. A ROS2-Nodejs package consist of a ROS 2 package, specifically an `ament-cmake` ROS 2 package, overlaid with a Nodejs package. This command can also be run from the `ros2` commandline as described in the [Using the command from the `ros2` commandline](#Using-the-command-from-the-ros2-commandline) section. 
 
 ## Key Features
-* Creates a ROS2 ament_cmake packages and overlays it with a custom Nodejs package.
+* Creates a ROS 2 ament_cmake package and overlays it with a custom Nodejs package.
 * `--typescript` commandline option to configure the package for use with TypeScript.
-* Includes the ROS2 JavaScript client library, 
+* Includes the ROS 2 JavaScript client library, 
 [rclnodejs](https://github.com/RobotWebTools/rclnodejs) as a runtime dependency.
 * Creates and example JavaScript/TypeScript ROS2 publisher node and ROS2 launch-description.
 * Customized `CMakeList.txt` `install()` rules to install key runtime files to the package share/ folder
+* `--no-ros-pkg` commandline option to create omit the ROS 2 package creation and only create a Nodejs package.
 
 # Usage #
 Create a new ROS2-Nodejs package basic usage:
@@ -102,7 +103,7 @@ We can now use the `ros2 launch` command to run the `example.launch.py` launch-d
 
 Launch `example.launch.py` as shown below:
 ```
-  ros2 launch ros2_nodejs example.launch.py
+  ros2 launch <package-name> example.launch.py
 ```
 To view the messages being published to the `foo` topic, open a separate shell configured with your ROS2 environment and enter:
 ```

--- a/package-creation-tool/lib/package_creator.js
+++ b/package-creation-tool/lib/package_creator.js
@@ -16,6 +16,7 @@ class PkgCreator {
       .option('--no-init', 'Do not run "npm init"')
       .option('--rclnodejs-version <x.y.z>', 'The version of rclnodejs to use')
       .option('--typescript', 'Configure as a TypeScript Node.js project')
+      .option('--no-ros-pkg', 'Do not create a ROS 2 package, e.g, package.xml')
       .option('--dependencies <ros_packages...>', 'list of ROS dependencies')
       .action((packageName, options) => {
         this.createPackage(packageName, options);
@@ -60,11 +61,15 @@ class PkgCreator {
     }
 
     if (options.noInit) {
-      cmd += ' --no-init';
+      cmd += ' --no-npm-init';
     }
 
     if (options.typescript) {
       cmd += ' --typescript';
+    }
+
+    if (!options.rosPkg) {
+      cmd += ' --no-ros-pkg';
     }
 
     if (options.dependencies) {

--- a/package-creation-tool/package.xml
+++ b/package-creation-tool/package.xml
@@ -3,9 +3,15 @@
 <package format="3">
   <name>rclnodejs_pkg_creation_tool</name>
   <version>0.0.1</version>
+<<<<<<< Upstream, based on origin/develop
   <description>Creates hybrid ros2-nodejs package</description>
   <maintainer email="5588978+wayneparrott@users.noreply.github.com">Wayne  Parrott</maintainer>
   <license>APL2</license>
+=======
+  <description>TODO: Package description</description>
+  <maintainer email="you@youremail.com">yourname</maintainer>
+  <license>TODO: License declaration</license>
+>>>>>>> 2bb8c33 Support node 13-17, ts 4.5, bump to v0.2, minor fixes and tweaks
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/package-creation-tool/package.xml
+++ b/package-creation-tool/package.xml
@@ -3,15 +3,9 @@
 <package format="3">
   <name>rclnodejs_pkg_creation_tool</name>
   <version>0.0.1</version>
-<<<<<<< Upstream, based on origin/develop
   <description>Creates hybrid ros2-nodejs package</description>
   <maintainer email="5588978+wayneparrott@users.noreply.github.com">Wayne  Parrott</maintainer>
   <license>APL2</license>
-=======
-  <description>TODO: Package description</description>
-  <maintainer email="you@youremail.com">yourname</maintainer>
-  <license>TODO: License declaration</license>
->>>>>>> 2bb8c33 Support node 13-17, ts 4.5, bump to v0.2, minor fixes and tweaks
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/package.json.em
+++ b/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/package.json.em
@@ -15,10 +15,10 @@
   "dependencies": {
   },
   "devDependencies": {
-    "@@types/node": "ts4.5",
-    "nodemon": "^2.0.15",
-    "ts-node": "^10.5.0",
-    "typescript": "^4.5.0"
+    "@@types/node": "^18.15.0",
+    "nodemon": "^2.0.21",
+    "ts-node": "^10.9.0",
+    "typescript": "^4.9.0"
   }
 
 }

--- a/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/tsconfig.json
+++ b/package-creation-tool/rclnodejs_pkg_creation_tool/resource/templates/typescript/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2019",
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+    "esModuleInterop": true,
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rclnodejs-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Commandline tools for the ROS2 rclnodejs client library",
   "main": "index.js",
   "bin": "./index.js",
@@ -35,7 +35,7 @@
     "chalk": "^4.1.0",
     "commander": "^6.2.1",
     "figlet": "^1.5.0",
-    "rclnodejs": "^0.21.0"
+    "rclnodejs": "^0.21.4"
   },
   "devDependencies": {
     "deep-equal": "^1.1.1",
@@ -47,6 +47,6 @@
     "rimraf": "^3.0.2"
   },
   "engines": {
-    "node": ">= 10.23.1 <18.0.0"
+    "node": ">= 14.0.0"
   }
 }


### PR DESCRIPTION
Adds --no-ros-pkg commandline arg
This flag omits the creation of a ROS package, e.g., no package.xml or CMakefile.txt.

Q: What is created when this flag is present?
A: Only a Nodejs package is created, e.g., package.json, example JS node.

Updated the tsconfig.json template support ES2020 target and libs.